### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ and follow the prompts. If you have  a completely fresh install of Ubuntu (which
 means you don't even have git installed, yet) then you can do the following
 
 ```bash
-wget https://github.com/samgdotson/ubuntu-post-installer/blob/master/ubuntu-post-installer.sh
-wget https://github.com/samgdotson/ubuntu-post-installer/blob/master/zotero_installer.sh
+wget https://raw.githubusercontent.com/samgdotson/ubuntu-post-installer/master/ubuntu-post-installer.sh
+wget https://raw.githubusercontent.com/samgdotson/ubuntu-post-installer/master/zotero_installer.sh
 bash ubuntu-post-installer.sh
 ```
 


### PR DESCRIPTION
Changed the CLA's for fresh Ubuntu installations. The current argument downloads the webpage as HTML rather than the .sh scripts that would install the software.